### PR TITLE
remove-system.security.cryptography.xml

### DIFF
--- a/src/CloudMigration.NET462Security/CloudMigration.NET462Security.csproj
+++ b/src/CloudMigration.NET462Security/CloudMigration.NET462Security.csproj
@@ -210,9 +210,6 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Security.Cryptography.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Security.Cryptography.Xml.4.4.0\lib\net461\System.Security.Cryptography.Xml.dll</HintPath>
-    </Reference>
     <Reference Include="System.Security.Principal.Windows, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Security.Principal.Windows.4.4.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>

--- a/src/CloudMigration.NET462Security/packages.config
+++ b/src/CloudMigration.NET462Security/packages.config
@@ -54,7 +54,6 @@
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net462" />
-  <package id="System.Security.Cryptography.Xml" version="4.4.0" targetFramework="net462" />
   <package id="System.Security.Principal.Windows" version="4.4.0" targetFramework="net462" />
   <package id="System.Text.Encodings.Web" version="4.4.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
Remove the package System.Security.Cryptography.Xml due to security alerts about this package from GitHub.  For more information on GitHub security alerts, visit https://help.github.com/en/articles/about-security-alerts-for-vulnerable-dependencies